### PR TITLE
Potential fix for code scanning alert no. 42: Query built from user-controlled sources

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
@@ -48,13 +48,16 @@ public class Servers {
   @ResponseBody
   public List<Server> sort(@RequestParam String column) throws Exception {
     List<Server> servers = new ArrayList<>();
+    List<String> allowedColumns = List.of("id", "hostname", "ip", "mac", "status", "description");
+
+    if (!allowedColumns.contains(column)) {
+      throw new IllegalArgumentException("Invalid column name: " + column);
+    }
+
+    String query = "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out of order' order by " + column;
 
     try (var connection = dataSource.getConnection()) {
-      try (var statement =
-          connection.prepareStatement(
-              "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out"
-                  + " of order' order by "
-                  + column)) {
+      try (var statement = connection.prepareStatement(query)) {
         try (var rs = statement.executeQuery()) {
           while (rs.next()) {
             Server server =


### PR DESCRIPTION
Potential fix for [https://github.com/IsraelPedroDamian/ISR_WebGoat/security/code-scanning/42](https://github.com/IsraelPedroDamian/ISR_WebGoat/security/code-scanning/42)

To fix the problem, we need to avoid using string concatenation to build the SQL query. Instead, we should use a prepared statement with a parameter placeholder for the `column` value. However, since the `column` value represents a column name and not a typical query parameter, we need to validate the `column` value against a whitelist of allowed column names to ensure it is safe to use in the query.

1. Create a list of allowed column names.
2. Validate the `column` parameter against this list.
3. If the `column` parameter is valid, construct the query using the validated column name.
4. If the `column` parameter is not valid, throw an exception or handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
